### PR TITLE
Argparse stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@
 *.out
 *.app
 
+# Script generated output
+include/showhelp.h
+
 # Emacs
 *~
 \#*#

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,16 @@ all: $(NAME)
 $(NAME): $(OBJS)
 	$(CC) $(CPPFLAGS) $(OBJS) -o $(NAME)
 
+src/argparser.o: include/showhelp.h
+
+include/showhelp.h: help
+# Use sed to transform plaintext helpfile
+# into escaped version for printing.
+# Thanks to esr for the trick.
+	sed <help >include/showhelp.h \
+		-e 's/\\/\\\\/g' -e 's/"/\\"/g' \
+		-e 's/.*/std::cerr << "&" << std::endl;/g'
+
 debug: CPPFLAGS += -g
 debug: all
 

--- a/help
+++ b/help
@@ -1,0 +1,16 @@
+-s, --strict
+	Exit on non-fatal errors.
+-t, --tolerant
+	Only exit on fatal commands. Enabled by default.
+-n, --new [FILE]
+	Creates a new bigram quoter and adds it to the stash.
+-o, --overwrite [FILE]
+	Overwrites an existing bigram quoter with a new bigram quoter.
+-l, --load [FILE]
+	Load data for a bigram quoter from save files and adds the to the stash.
+-m, --merge [FILE]
+	Merge stashed bigram quoters into a new bigram quoter.
+-f, --feed [FILE]
+	Feeds a text file into the stashed bigram quoters.
+-b, --build
+	Constructs a single sentences for each stashed bigram quoter.

--- a/include/argparser.hpp
+++ b/include/argparser.hpp
@@ -19,23 +19,23 @@ namespace ArgParser {
 		{0, 0, 0, 0}
 	};
 
-	void parseArgs(int argc, char** argv);
-	void option_new(int argc, char** argv,
+	void parseArgs(int argc, char **argv);
+	void option_new(int argc, char **argv,
 			std::vector<std::pair<Quoter, std::string>>& stash,
 		        bool strictMode, bool& strictMode_exit);
-	void option_load(int argc, char** argv,
+	void option_load(int argc, char **argv,
 			 std::vector<std::pair<Quoter, std::string>>& stash,
 			 bool strictMode, bool& strictMode_exit);
-	void option_overwrite(int argc, char** argv,
+	void option_overwrite(int argc, char **argv,
 			 std::vector<std::pair<Quoter, std::string>>& stash,
 			 bool strictMode, bool& strictMode_exit);
-	void option_merge(int argc, char** argv,
+	void option_merge(int argc, char **argv,
 			  std::vector<std::pair<Quoter, std::string>>& stash,
 			  bool strictMode, bool& strictMode_exit);
-	void option_feed(int argc, char** argv,
+	void option_feed(int argc, char **argv,
 			 std::vector<std::pair<Quoter, std::string>>& stash,
 			 bool strictMode, bool& strictMode_exit);
-	void option_build(int argc, char** argv,
+	void option_build(int argc, char **argv,
 			  std::vector<std::pair<Quoter, std::string>>& stash,
 			  bool strictMode, bool& strictMode_exit);
         bool filenameInStash(std::vector<std::pair<Quoter, std::string>>& stash,

--- a/src/argparser.cpp
+++ b/src/argparser.cpp
@@ -1,4 +1,5 @@
-/* TODO
+/*
+ * TODO
  *  - Check if bigram quoter has been fed before building a sentence.
  *  - Enforce a file extension (maybe .bq). If the file extension is not
  *    included with a savefile string, it will be appended automatically.
@@ -19,9 +20,9 @@
  */
 #define UNUSED(x) ((void)(x))
 
-const char* opts_string="stn:o:l:m:f:b";
+const char *opts_string = "stn:o:l:m:f:b";
 
-void ArgParser::parseArgs(int argc, char** argv) {
+void ArgParser::parseArgs(int argc, char **argv) {
 	if (argc == 1) {
 		std::cerr << argv[0] << ": no arguments given\n" << std::endl;
 		#include "showhelp.h"
@@ -31,17 +32,17 @@ void ArgParser::parseArgs(int argc, char** argv) {
 	        exit(1);
 	}
 	std::vector<std::pair<Quoter, std::string>> stash;
-	bool strictMode=false, strictMode_exit=false;
-	int o, argi=1;
-	while ((o=getopt_long(argc, argv, opts_string, opts_long, &argi)) != -1) {
+	bool strictMode = false, strictMode_exit = false;
+	int o, argi = 1;
+	while ((o = getopt_long(argc, argv, opts_string, opts_long, &argi)) != -1) {
 		switch(o) {
 		case 's':
 			// Switch to strict mode.
-			strictMode=true;
+			strictMode = true;
 			break;
 		case 't':
 			// Switch to tolerant mode.
-			strictMode=false;
+			strictMode = false;
 			break;
 		case 'n':
 			// Create and save a new bigram quoter
@@ -92,11 +93,11 @@ void ArgParser::parseArgs(int argc, char** argv) {
 
 	// Write stashed bigram quoters to their respective save files.
 	std::vector<std::pair<Quoter, std::string>>::iterator s_it;
-        for (s_it=stash.begin(); s_it!=stash.end(); ++s_it)
+        for (s_it = stash.begin(); s_it != stash.end(); ++s_it)
 		s_it->first.writeData(s_it->second);
 }
 
-void ArgParser::option_new(int argc, char** argv,
+void ArgParser::option_new(int argc, char **argv,
 			   std::vector<std::pair<Quoter, std::string>>& stash,
 			   bool strictMode, bool& strictMode_exit) {
 	UNUSED(argc);
@@ -115,7 +116,7 @@ void ArgParser::option_new(int argc, char** argv,
 	stash.push_back(newPair);
 }
 
-void ArgParser::option_overwrite(int argc, char** argv,
+void ArgParser::option_overwrite(int argc, char **argv,
 				 std::vector<std::pair<Quoter, std::string>>& stash,
 				 bool strictMode, bool& strictMode_exit) {
 	UNUSED(argc);
@@ -134,7 +135,7 @@ void ArgParser::option_overwrite(int argc, char** argv,
 	stash.push_back(newPair);
 }
 
-void ArgParser::option_load(int argc, char** argv,
+void ArgParser::option_load(int argc, char **argv,
 			    std::vector<std::pair<Quoter, std::string>>& stash,
 			    bool strictMode, bool& strictMode_exit) {
 	UNUSED(argc);
@@ -174,7 +175,7 @@ void ArgParser::option_load(int argc, char** argv,
 	}
 }
 
-void ArgParser::option_merge(int argc, char** argv,
+void ArgParser::option_merge(int argc, char **argv,
 			     std::vector<std::pair<Quoter, std::string>>& stash,
 			     bool strictMode, bool& strictMode_exit) {
 	UNUSED(argc);
@@ -193,7 +194,7 @@ void ArgParser::option_merge(int argc, char** argv,
 	return;
 }
 
-void ArgParser::option_feed(int argc, char** argv,
+void ArgParser::option_feed(int argc, char **argv,
 			    std::vector<std::pair<Quoter, std::string>>& stash,
 			    bool strictMode, bool& strictMode_exit) {
 	UNUSED(argc);
@@ -209,7 +210,7 @@ void ArgParser::option_feed(int argc, char** argv,
 		return;
 	}
 	std::vector<std::pair<Quoter, std::string>>::iterator s_it;
-	for (s_it=stash.begin(); s_it!=stash.end(); ++s_it) {
+	for (s_it = stash.begin(); s_it != stash.end(); ++s_it) {
 		try {
 			s_it->first.feed_file(filename);
 		} catch (QuoterError& e) {
@@ -222,7 +223,7 @@ void ArgParser::option_feed(int argc, char** argv,
 	}
 }
 
-void ArgParser::option_build(int argc, char** argv,
+void ArgParser::option_build(int argc, char **argv,
 			     std::vector<std::pair<Quoter, std::string>>& stash,
 			     bool strictMode, bool& strictMode_exit) {
 	UNUSED(argc);
@@ -235,14 +236,14 @@ void ArgParser::option_build(int argc, char** argv,
 		return;
 	}
 	std::vector<std::pair<Quoter, std::string>>::iterator s_it;
-	for (s_it=stash.begin(); s_it!=stash.end(); ++s_it)
+	for (s_it = stash.begin(); s_it != stash.end(); ++s_it)
 		std::cout << s_it->first.buildSentence() << std::endl;
 }
 
 bool ArgParser::filenameInStash(std::vector<std::pair<Quoter, std::string>>& stash,
 				const std::string& filename) {
 	std::vector<std::pair<Quoter, std::string>>::iterator s_it;
-	for (s_it=stash.begin(); s_it!=stash.end(); ++s_it)
+	for (s_it = stash.begin(); s_it != stash.end(); ++s_it)
 		if (s_it->second == filename)
 			return true;
 	return false;

--- a/src/argparser.cpp
+++ b/src/argparser.cpp
@@ -13,6 +13,12 @@
 #include <unistd.h>
 #include "argparser.hpp"
 
+/*
+ * Define a temporary macro to mark passed arguments as unused.
+ * TODO: use them soon or stop passing them.
+ */
+#define UNUSED(x) ((void)(x))
+
 const char* opts_string="stn:o:l:m:f:b";
 
 void ArgParser::parseArgs(int argc, char** argv) {
@@ -93,6 +99,7 @@ void ArgParser::parseArgs(int argc, char** argv) {
 void ArgParser::option_new(int argc, char** argv,
 			   std::vector<std::pair<Quoter, std::string>>& stash,
 			   bool strictMode, bool& strictMode_exit) {
+	UNUSED(argc);
 	std::string filename(optarg);
 	if (access(optarg, F_OK) != -1 || filenameInStash(stash, filename)) {
 		std::cerr << argv[0]
@@ -111,6 +118,7 @@ void ArgParser::option_new(int argc, char** argv,
 void ArgParser::option_overwrite(int argc, char** argv,
 				 std::vector<std::pair<Quoter, std::string>>& stash,
 				 bool strictMode, bool& strictMode_exit) {
+	UNUSED(argc);
 	std::string filename(optarg);
 	if (access(optarg, F_OK) == -1 || filenameInStash(stash, filename)) {
 		std::cerr << argv[0]
@@ -129,6 +137,7 @@ void ArgParser::option_overwrite(int argc, char** argv,
 void ArgParser::option_load(int argc, char** argv,
 			    std::vector<std::pair<Quoter, std::string>>& stash,
 			    bool strictMode, bool& strictMode_exit) {
+	UNUSED(argc);
 	std::string filename(optarg);
 	if (filenameInStash(stash, filename)) {
 		std::cerr << argv[0]
@@ -168,6 +177,7 @@ void ArgParser::option_load(int argc, char** argv,
 void ArgParser::option_merge(int argc, char** argv,
 			     std::vector<std::pair<Quoter, std::string>>& stash,
 			     bool strictMode, bool& strictMode_exit) {
+	UNUSED(argc);
 	std::string filename(optarg);
 	if (access(optarg, F_OK) != -1 || filenameInStash(stash, filename)) {
 		std::cerr << argv[0]
@@ -186,6 +196,7 @@ void ArgParser::option_merge(int argc, char** argv,
 void ArgParser::option_feed(int argc, char** argv,
 			    std::vector<std::pair<Quoter, std::string>>& stash,
 			    bool strictMode, bool& strictMode_exit) {
+	UNUSED(argc);
 	std::string filename(optarg);
 	if (access(optarg, F_OK) == -1) {
 		std::cerr << argv[0]
@@ -214,6 +225,7 @@ void ArgParser::option_feed(int argc, char** argv,
 void ArgParser::option_build(int argc, char** argv,
 			     std::vector<std::pair<Quoter, std::string>>& stash,
 			     bool strictMode, bool& strictMode_exit) {
+	UNUSED(argc);
 	if (stash.empty()) {
 		std::cerr << argv[0]
 			  << ": cannot build sentences; stash is empty"

--- a/src/argparser.cpp
+++ b/src/argparser.cpp
@@ -17,8 +17,11 @@ const char* opts_string="stn:o:l:m:f:b";
 
 void ArgParser::parseArgs(int argc, char** argv) {
 	if (argc == 1) {
-		std::cerr << argv[0] << ": no arguments given" << std::endl;
-		//TODO: Print out help.
+		std::cerr << argv[0] << ": no arguments given\n" << std::endl;
+		#include "showhelp.h"
+		std::cerr <<
+			"\nSee https://github.com/JoshuaBrockschmidt/bigram_quoter"
+			"\n" << std::endl;
 	        exit(1);
 	}
 	std::vector<std::pair<Quoter, std::string>> stash;


### PR DESCRIPTION
- Including a text file which is sourced for help output when no arguments are
  given
- Using a little preprocessor magic to mark variables as unused to get rid of
  complaint messages from the compiler (which should be heeded - use the args
  soon or don't pass them period)
- Linux-ifying the source to match up with the reformats to other files
